### PR TITLE
fix: adapt to opencode 1.18 sandboxes format and connection errors

### DIFF
--- a/app/src/main/java/com/opencode/remote/data/api/OpenCodeApiClient.kt
+++ b/app/src/main/java/com/opencode/remote/data/api/OpenCodeApiClient.kt
@@ -13,10 +13,14 @@ import io.ktor.client.engine.okhttp.*
 import io.ktor.client.plugins.*
 import io.ktor.client.plugins.contentnegotiation.*
 import io.ktor.client.request.*
+import io.ktor.client.statement.*
 import io.ktor.http.*
 import io.ktor.serialization.kotlinx.json.*
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.SerializationException
 import javax.inject.Inject
+import java.net.ConnectException
+import java.net.SocketTimeoutException
 import java.net.URLEncoder
 import javax.net.ssl.SSLContext
 import javax.net.ssl.X509TrustManager
@@ -38,6 +42,15 @@ import javax.net.ssl.TrustManager
  *   GET  /session/{id}/todo         → List<TodoItem>
  *   GET  /project/current           → ProjectInfo
  */
+/**
+ * Result of a connectivity test, carrying a human-readable reason on failure
+ * so the UI can show why the connection could not be established.
+ */
+data class ConnectionTestResult(
+    val success: Boolean,
+    val error: String? = null,
+)
+
 class OConnectorApiClient @Inject constructor(
     private val json: Json,
 ) {
@@ -395,13 +408,32 @@ class OConnectorApiClient @Inject constructor(
         return allSessions
     }
 
-    /** Test connectivity by hitting a lightweight endpoint */
-    suspend fun testConnection(): Boolean = try {
-        getCurrentProject()
-        true
+    /** Test connectivity by hitting a lightweight endpoint. */
+    suspend fun testConnection(): ConnectionTestResult = try {
+        val response = client.get("/project/current")
+        if (response.status.isSuccess()) {
+            ConnectionTestResult(success = true)
+        } else {
+            ConnectionTestResult(
+                success = false,
+                error = "HTTP ${response.status.value} (GET /project/current)"
+            )
+        }
     } catch (e: Exception) {
-        Log.w(TAG, "Test connection failed: ${e.javaClass.simpleName}: ${e.message}")
-        false
+        val detail = describeError(e)
+        Log.w(TAG, "Test connection failed: $detail")
+        ConnectionTestResult(success = false, error = detail)
+    }
+
+    /** Build a human-readable reason for a connection failure. */
+    private fun describeError(e: Exception): String = when (e) {
+        is ClientRequestException -> "HTTP ${e.response.status.value} (GET /project/current)"
+        is ServerResponseException -> "HTTP ${e.response.status.value} (GET /project/current)"
+        is HttpRequestTimeoutException -> "请求超时"
+        is SocketTimeoutException -> "连接/读取超时"
+        is ConnectException -> "无法建立 TCP 连接"
+        is SerializationException -> "响应解析失败: ${e.message?.take(200)}"
+        else -> "${e.javaClass.simpleName}: ${e.message?.take(200)}"
     }
 
     // ─── Agents ─────────────────────────────────────────────────────────

--- a/app/src/main/java/com/opencode/remote/data/api/dto/CommonDtos.kt
+++ b/app/src/main/java/com/opencode/remote/data/api/dto/CommonDtos.kt
@@ -7,25 +7,19 @@ import kotlinx.serialization.json.JsonElement
 /**
  * 实际 API: GET /project/current
  * 服务器返回 flat JSON: {"id":"global","worktree":"/","time":{...},"sandboxes":[...]}
+ * sandboxes 在 opencode 1.18+ 返回字符串数组（工作区目录），更早版本可能是对象数组。
  */
 @Serializable
 data class ProjectInfo(
     val id: String = "",
     val worktree: String? = null,
     val time: ProjectTime? = null,
-    val sandboxes: List<ProjectSandbox> = emptyList(),
+    val sandboxes: List<String> = emptyList(),
 )
 
 @Serializable
 data class ProjectTime(
     val created: Long? = null,
-)
-
-@Serializable
-data class ProjectSandbox(
-    val id: String? = null,
-    val name: String? = null,
-    val directory: String? = null,
 )
 
 /**

--- a/app/src/main/java/com/opencode/remote/data/repository/OpenCodeRepository.kt
+++ b/app/src/main/java/com/opencode/remote/data/repository/OpenCodeRepository.kt
@@ -3,6 +3,7 @@ package com.opencode.remote.data.repository
 import android.content.Context
 import android.content.SharedPreferences
 import android.util.Log
+import com.opencode.remote.data.api.ConnectionTestResult
 import com.opencode.remote.data.api.OConnectorApiClient
 import com.opencode.remote.data.api.OConnectorSseClient
 import com.opencode.remote.data.api.dto.*
@@ -85,7 +86,7 @@ interface OConnectorRepository {
 
     // ─── Test Connection ─────────────────────────────────────────────
 
-    suspend fun testConnection(): Boolean
+    suspend fun testConnection(): ConnectionTestResult
 
     // ─── Agents ─────────────────────────────────────────────────────────
 
@@ -442,7 +443,7 @@ class OConnectorRepositoryImpl @Inject constructor(
 
     // ─── Test Connection ─────────────────────────────────────────────
 
-    override suspend fun testConnection(): Boolean =
+    override suspend fun testConnection(): ConnectionTestResult =
         requireClient().testConnection()
 
     // ─── Agents ─────────────────────────────────────────────────────────

--- a/app/src/main/java/com/opencode/remote/ui/connection/ConnectionViewModel.kt
+++ b/app/src/main/java/com/opencode/remote/ui/connection/ConnectionViewModel.kt
@@ -132,11 +132,11 @@ class ConnectionViewModel @Inject constructor(
                 preferences.saveConfig(config)
 
                 // Test connection on IO thread
-                val success = withContext(Dispatchers.IO) {
+                val testResult = withContext(Dispatchers.IO) {
                     repository.testConnection()
                 }
 
-                if (success) {
+                if (testResult.success) {
                     // Only start SSE service after connection is confirmed reachable
                     repository.startSseService()
                     // Pre-load agent list for later use
@@ -149,7 +149,7 @@ class ConnectionViewModel @Inject constructor(
                     _uiState.update {
                         it.copy(
                             isConnecting = false,
-                            error = s.errCannotConnect
+                            error = testResult.error?.let { "${s.errCannotConnect}\n$it" } ?: s.errCannotConnect
                         )
                     }
                 }
@@ -218,9 +218,9 @@ class ConnectionViewModel @Inject constructor(
                 withContext(Dispatchers.IO) { repository.connect(config) }
                 repository.setServerName(state.serverName.trim())
 
-                val success = withContext(Dispatchers.IO) { repository.testConnection() }
+                val testResult = withContext(Dispatchers.IO) { repository.testConnection() }
 
-                if (success) {
+                if (testResult.success) {
                     // Only start SSE service after connection is confirmed reachable
                     repository.startSseService()
                     serverManager.saveLastActiveServerId(serverId)
@@ -230,7 +230,7 @@ class ConnectionViewModel @Inject constructor(
                     _uiState.update {
                         it.copy(
                             isConnecting = false,
-                            error = s.errCannotConnect
+                            error = testResult.error?.let { "${s.errCannotConnect}\n$it" } ?: s.errCannotConnect
                         )
                     }
                 }

--- a/app/src/main/java/com/opencode/remote/ui/serverlist/ServerListViewModel.kt
+++ b/app/src/main/java/com/opencode/remote/ui/serverlist/ServerListViewModel.kt
@@ -91,11 +91,11 @@ class ServerListViewModel @Inject constructor(
                 }
                 repository.setServerName(server.name)
 
-                val success = withContext(Dispatchers.IO) {
+                val testResult = withContext(Dispatchers.IO) {
                     repository.testConnection()
                 }
 
-                if (success) {
+                if (testResult.success) {
                     // Only start SSE service after connection is confirmed reachable
                     repository.startSseService()
                     serverManager.saveLastActiveServerId(serverId)
@@ -108,7 +108,10 @@ class ServerListViewModel @Inject constructor(
                 } else {
                     repository.disconnect()
                     _uiState.update {
-                        it.copy(isConnecting = false, error = "Connection test failed")
+                        it.copy(
+                            isConnecting = false,
+                            error = testResult.error?.let { "Connection test failed: $it" } ?: "Connection test failed",
+                        )
                     }
                 }
             } catch (e: Exception) {


### PR DESCRIPTION
## 摘要

`ProjectInfo.sandboxes` 的 DTO 原本声明为 `ProjectSandbox` 对象数组
（id/name/directory），但服务器实际上一直返回纯字符串数组
（按官方 API schema，`sandboxes` 为 `string[]`，即工作区/sandbox 目录列表）。

当 sandboxes 为空数组 `[]` 时，类型不匹配不会暴露；一旦项目存在真实
sandbox（例如 `["D:\\Workspace\\..."]`），kotlinx 反序列化就会抛出
`SerializationException`，导致 `testConnection()` 恒失败、应用无法连接服务器。

## 改动

- `ProjectInfo.sandboxes`：`List<ProjectSandbox>` → `List<String>`，删除 `ProjectSandbox`
- `testConnection()`：改为检查 `GET /project/current` 的 HTTP 状态码
  （不再反序列化响应体），返回 `ConnectionTestResult(success, error)`
- `describeError()`：给出人类可读的错误原因（HTTP 状态码 / 超时 / TCP / 解析失败）
- 两个 ViewModel：在 UI 错误信息中展示详细的失败原因

## 测试

- `assembleDebug` 构建通过
- 已用真实 opencode 服务器验证（`/project/current`、`/session?list`、SSE）