### PR TITLE
Fix/session loading worktree sandbox

### DIFF
--- a/app/src/main/java/com/opencode/remote/data/api/OpenCodeApiClient.kt
+++ b/app/src/main/java/com/opencode/remote/data/api/OpenCodeApiClient.kt
@@ -13,10 +13,14 @@ import io.ktor.client.engine.okhttp.*
 import io.ktor.client.plugins.*
 import io.ktor.client.plugins.contentnegotiation.*
 import io.ktor.client.request.*
+import io.ktor.client.statement.*
 import io.ktor.http.*
 import io.ktor.serialization.kotlinx.json.*
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.SerializationException
 import javax.inject.Inject
+import java.net.ConnectException
+import java.net.SocketTimeoutException
 import java.net.URLEncoder
 import javax.net.ssl.SSLContext
 import javax.net.ssl.X509TrustManager
@@ -38,6 +42,15 @@ import javax.net.ssl.TrustManager
  *   GET  /session/{id}/todo         → List<TodoItem>
  *   GET  /project/current           → ProjectInfo
  */
+/**
+ * Result of a connectivity test, carrying a human-readable reason on failure
+ * so the UI can show why the connection could not be established.
+ */
+data class ConnectionTestResult(
+    val success: Boolean,
+    val error: String? = null,
+)
+
 class OConnectorApiClient @Inject constructor(
     private val json: Json,
 ) {
@@ -395,13 +408,32 @@ class OConnectorApiClient @Inject constructor(
         return allSessions
     }
 
-    /** Test connectivity by hitting a lightweight endpoint */
-    suspend fun testConnection(): Boolean = try {
-        getCurrentProject()
-        true
+    /** Test connectivity by hitting a lightweight endpoint. */
+    suspend fun testConnection(): ConnectionTestResult = try {
+        val response = client.get("/project/current")
+        if (response.status.isSuccess()) {
+            ConnectionTestResult(success = true)
+        } else {
+            ConnectionTestResult(
+                success = false,
+                error = "HTTP ${response.status.value} (GET /project/current)"
+            )
+        }
     } catch (e: Exception) {
-        Log.w(TAG, "Test connection failed: ${e.javaClass.simpleName}: ${e.message}")
-        false
+        val detail = describeError(e)
+        Log.w(TAG, "Test connection failed: $detail")
+        ConnectionTestResult(success = false, error = detail)
+    }
+
+    /** Build a human-readable reason for a connection failure. */
+    private fun describeError(e: Exception): String = when (e) {
+        is ClientRequestException -> "HTTP ${e.response.status.value} (GET /project/current)"
+        is ServerResponseException -> "HTTP ${e.response.status.value} (GET /project/current)"
+        is HttpRequestTimeoutException -> "请求超时"
+        is SocketTimeoutException -> "连接/读取超时"
+        is ConnectException -> "无法建立 TCP 连接"
+        is SerializationException -> "响应解析失败: ${e.message?.take(200)}"
+        else -> "${e.javaClass.simpleName}: ${e.message?.take(200)}"
     }
 
     // ─── Agents ─────────────────────────────────────────────────────────

--- a/app/src/main/java/com/opencode/remote/data/api/OpenCodeApiClient.kt
+++ b/app/src/main/java/com/opencode/remote/data/api/OpenCodeApiClient.kt
@@ -357,6 +357,8 @@ class OConnectorApiClient @Inject constructor(
      * Strategy:
      *   1. GET /project → discover all known projects
      *   2. For normal projects (real worktree): GET /session?list&directory=<worktree>
+     *      — also query every sandbox path: the stored worktree may be stale (e.g. the
+     *        directory was moved to another drive) while sessions live under a sandbox.
      *   3. For global project (worktree="/"): GET /session?list&directory=/&scope=project
      *      — scope=project skips directory matching, returns ALL sessions for that project_id
      *   4. Merge and deduplicate all results
@@ -381,7 +383,12 @@ class OConnectorApiClient @Inject constructor(
                                 // scope=project skips directory filter, returns all sessions for this project_id
                                 listSessions(directory = project.worktree ?: "/", scope = "project")
                             } else {
-                                listSessions(directory = project.worktree)
+                                // Query the worktree AND every sandbox path. The stored worktree may
+                                // point to a moved/removed location (e.g. another drive), while the
+                                // sessions actually live under a sandbox path. Overlapping results
+                                // are deduplicated below by session id.
+                                val directories = (listOfNotNull(project.worktree) + project.sandboxes).distinct()
+                                directories.flatMap { dir -> listSessions(directory = dir) }
                             }
                         } catch (e: Exception) {
                             Log.w(TAG, "Failed to load sessions for project ${project.id} (${project.worktree}): ${e.message}")

--- a/app/src/main/java/com/opencode/remote/data/api/dto/CommonDtos.kt
+++ b/app/src/main/java/com/opencode/remote/data/api/dto/CommonDtos.kt
@@ -7,25 +7,19 @@ import kotlinx.serialization.json.JsonElement
 /**
  * 实际 API: GET /project/current
  * 服务器返回 flat JSON: {"id":"global","worktree":"/","time":{...},"sandboxes":[...]}
+ * sandboxes 在 opencode 1.18+ 返回字符串数组（工作区目录），更早版本可能是对象数组。
  */
 @Serializable
 data class ProjectInfo(
     val id: String = "",
     val worktree: String? = null,
     val time: ProjectTime? = null,
-    val sandboxes: List<ProjectSandbox> = emptyList(),
+    val sandboxes: List<String> = emptyList(),
 )
 
 @Serializable
 data class ProjectTime(
     val created: Long? = null,
-)
-
-@Serializable
-data class ProjectSandbox(
-    val id: String? = null,
-    val name: String? = null,
-    val directory: String? = null,
 )
 
 /**

--- a/app/src/main/java/com/opencode/remote/data/repository/OpenCodeRepository.kt
+++ b/app/src/main/java/com/opencode/remote/data/repository/OpenCodeRepository.kt
@@ -3,6 +3,7 @@ package com.opencode.remote.data.repository
 import android.content.Context
 import android.content.SharedPreferences
 import android.util.Log
+import com.opencode.remote.data.api.ConnectionTestResult
 import com.opencode.remote.data.api.OConnectorApiClient
 import com.opencode.remote.data.api.OConnectorSseClient
 import com.opencode.remote.data.api.dto.*
@@ -85,7 +86,7 @@ interface OConnectorRepository {
 
     // ─── Test Connection ─────────────────────────────────────────────
 
-    suspend fun testConnection(): Boolean
+    suspend fun testConnection(): ConnectionTestResult
 
     // ─── Agents ─────────────────────────────────────────────────────────
 
@@ -442,7 +443,7 @@ class OConnectorRepositoryImpl @Inject constructor(
 
     // ─── Test Connection ─────────────────────────────────────────────
 
-    override suspend fun testConnection(): Boolean =
+    override suspend fun testConnection(): ConnectionTestResult =
         requireClient().testConnection()
 
     // ─── Agents ─────────────────────────────────────────────────────────

--- a/app/src/main/java/com/opencode/remote/ui/connection/ConnectionViewModel.kt
+++ b/app/src/main/java/com/opencode/remote/ui/connection/ConnectionViewModel.kt
@@ -132,11 +132,11 @@ class ConnectionViewModel @Inject constructor(
                 preferences.saveConfig(config)
 
                 // Test connection on IO thread
-                val success = withContext(Dispatchers.IO) {
+                val testResult = withContext(Dispatchers.IO) {
                     repository.testConnection()
                 }
 
-                if (success) {
+                if (testResult.success) {
                     // Only start SSE service after connection is confirmed reachable
                     repository.startSseService()
                     // Pre-load agent list for later use
@@ -149,7 +149,7 @@ class ConnectionViewModel @Inject constructor(
                     _uiState.update {
                         it.copy(
                             isConnecting = false,
-                            error = s.errCannotConnect
+                            error = testResult.error?.let { "${s.errCannotConnect}\n$it" } ?: s.errCannotConnect
                         )
                     }
                 }
@@ -218,9 +218,9 @@ class ConnectionViewModel @Inject constructor(
                 withContext(Dispatchers.IO) { repository.connect(config) }
                 repository.setServerName(state.serverName.trim())
 
-                val success = withContext(Dispatchers.IO) { repository.testConnection() }
+                val testResult = withContext(Dispatchers.IO) { repository.testConnection() }
 
-                if (success) {
+                if (testResult.success) {
                     // Only start SSE service after connection is confirmed reachable
                     repository.startSseService()
                     serverManager.saveLastActiveServerId(serverId)
@@ -230,7 +230,7 @@ class ConnectionViewModel @Inject constructor(
                     _uiState.update {
                         it.copy(
                             isConnecting = false,
-                            error = s.errCannotConnect
+                            error = testResult.error?.let { "${s.errCannotConnect}\n$it" } ?: s.errCannotConnect
                         )
                     }
                 }

--- a/app/src/main/java/com/opencode/remote/ui/serverlist/ServerListViewModel.kt
+++ b/app/src/main/java/com/opencode/remote/ui/serverlist/ServerListViewModel.kt
@@ -91,11 +91,11 @@ class ServerListViewModel @Inject constructor(
                 }
                 repository.setServerName(server.name)
 
-                val success = withContext(Dispatchers.IO) {
+                val testResult = withContext(Dispatchers.IO) {
                     repository.testConnection()
                 }
 
-                if (success) {
+                if (testResult.success) {
                     // Only start SSE service after connection is confirmed reachable
                     repository.startSseService()
                     serverManager.saveLastActiveServerId(serverId)
@@ -108,7 +108,10 @@ class ServerListViewModel @Inject constructor(
                 } else {
                     repository.disconnect()
                     _uiState.update {
-                        it.copy(isConnecting = false, error = "Connection test failed")
+                        it.copy(
+                            isConnecting = false,
+                            error = testResult.error?.let { "Connection test failed: $it" } ?: "Connection test failed",
+                        )
                     }
                 }
             } catch (e: Exception) {


### PR DESCRIPTION
## 问题

部分项目在 App 中加载不出会话。

根因：项目注册的 `worktree` 路径已失效（目录被移动或删除），而会话实际存储在 `sandbox` 路径下。

服务器 `GET /session?list&directory=X` 仅在 X 能解析到项目时才返回会话；按失效的 worktree 查询永远返回空列表。

## 修复

`OConnectorApiClient.listAllSessions()` 对每个非 global 项目：

- 同时按 `worktree` 和所有 `sandbox` 路径查询会话（之前只查 worktree）
- 通过 `seenIds` 按 session id 去重，worktree/sandbox 结果重叠无影响

## 验证

- `assembleDebug` 构建通过
- 服务器实测：按 sandbox 路径查询能返回会话，按失效 worktree 查询返回空
- 改动仅限 `OpenCodeApiClient.kt`

本 PR（#19）是在 #18（fix: adapt to opencode 1.18 sandboxes format and connection errors）的基础上创建的，共 2 个提交：
- bf1c89a — 1.18 sandboxes 格式兼容（即 #18 的内容）
- 990ac53 — 本次修复（按 sandbox 路径查询会话）
原因：本次改动依赖 #18 中 ProjectInfo.sandboxes: List<String> 的类型变更，在 main（仍为对象数组）上无法编译。