### PR TITLE
Fix: The language selection is not persisted after changing.

### DIFF
--- a/app/src/main/java/com/opencode/remote/ui/AppNavigation.kt
+++ b/app/src/main/java/com/opencode/remote/ui/AppNavigation.kt
@@ -27,7 +27,6 @@ import com.opencode.remote.ui.sessions.SessionsScreen
 import com.opencode.remote.ui.sessions.ProjectSessionsScreen
 import com.opencode.remote.ui.chat.ChatScreen
 import com.opencode.remote.ui.help.HelpScreen
-import com.opencode.remote.ui.strings.AppLocale
 import com.opencode.remote.ui.update.UpdateViewModel
 
 object Routes {
@@ -118,10 +117,7 @@ fun OConnectorApp(
                 onAddServer = { navController.navigate(Routes.ADD_SERVER) },
                 onServerSelected = { serverId -> viewModel.connectToServer(serverId) },
                 onHelp = { navController.navigate(Routes.HELP) },
-                onToggleLanguage = {
-                    val newLang = if (AppLocale.language == "en") "zh" else "en"
-                    AppLocale.language = newLang
-                },
+                onToggleLanguage = { viewModel.toggleLanguage() },
             )
         }
 

--- a/app/src/main/java/com/opencode/remote/ui/serverlist/ServerListViewModel.kt
+++ b/app/src/main/java/com/opencode/remote/ui/serverlist/ServerListViewModel.kt
@@ -6,14 +6,17 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.opencode.remote.data.api.dto.ServerInfo
 import com.opencode.remote.data.datastore.ConnectionConfig
+import com.opencode.remote.data.datastore.ConnectionPreferences
 import com.opencode.remote.data.datastore.ServerManager
 import com.opencode.remote.data.repository.OConnectorRepository
+import com.opencode.remote.ui.strings.AppLocale
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -23,6 +26,7 @@ import javax.inject.Inject
 class ServerListViewModel @Inject constructor(
     private val serverManager: ServerManager,
     private val repository: OConnectorRepository,
+    private val preferences: ConnectionPreferences,
 ) : ViewModel() {
 
     @Immutable
@@ -41,6 +45,7 @@ class ServerListViewModel @Inject constructor(
     }
 
     init {
+        loadPreferences()
         viewModelScope.launch {
             serverManager.migrateIfNeeded()
         }
@@ -131,6 +136,26 @@ class ServerListViewModel @Inject constructor(
     fun deleteServer(id: String) {
         viewModelScope.launch {
             serverManager.deleteServer(id)
+        }
+    }
+
+    /** Load persisted language and dark mode into AppLocale at startup. */
+    private fun loadPreferences() {
+        viewModelScope.launch {
+            preferences.language.take(1).collect { lang ->
+                AppLocale.language = lang
+            }
+            preferences.darkMode.take(1).collect { enabled ->
+                AppLocale.darkMode = enabled
+            }
+        }
+    }
+
+    fun toggleLanguage() {
+        viewModelScope.launch {
+            val newLang = if (AppLocale.language == "en") "zh" else "en"
+            AppLocale.language = newLang
+            preferences.saveLanguage(newLang)
         }
     }
 }


### PR DESCRIPTION
## 问题
顶栏的语言切换按钮只修改了内存中的 `AppLocale.language`，从未写入
DataStore；而持久化的语言值只在"添加服务器"页面（`ConnectionScreen`）中
加载，但应用的启动页是 `ServerListScreen`。因此每次冷启动后，所选语言都会
被重置为默认的英文。

## 改动
- `ServerListViewModel`：注入 `ConnectionPreferences`；新增 `loadPreferences()`，
  在启动时把持久化的语言和深色模式读入 `AppLocale`（ServerList 是启动目的地，
  其 ViewModel 在应用启动时即被创建）；新增 `toggleLanguage()`，切换语言并
  通过 `preferences.saveLanguage()` 持久化。
- `AppNavigation`：语言切换按钮改为调用 `viewModel.toggleLanguage()`，
  不再直接修改 `AppLocale`。

顺带修复了深色模式在启动时同样不加载的问题（根因相同）。

## 验证
- 点击语言按钮切换为中文 → 强制停止应用 → 重新打开 → 界面保持中文。